### PR TITLE
Fix pdftoppm -tiff -gray/-mono incorrect output.

### DIFF
--- a/splash/SplashBitmap.h
+++ b/splash/SplashBitmap.h
@@ -109,6 +109,7 @@ private:
   Guchar *alpha;		// pointer to row zero of the alpha data
 				//   (always top-down)
   GooList *separationList; // list of spot colorants and their mapping functions
+  SplashColorMode imageWriterFormat; // input format of ImgWriter
 
   friend class Splash;
 };


### PR DESCRIPTION
- SplashBitmap has imageWriterFormat that ImgWriter
  should accept.